### PR TITLE
add Blackbox filter to Artikel view

### DIFF
--- a/at.medevit.ch.artikelstamm.elexis.common/src/at/medevit/ch/artikelstamm/elexis/common/ui/cv/ArtikelstammCodeSelectorFactory.java
+++ b/at.medevit.ch.artikelstamm.elexis.common/src/at/medevit/ch/artikelstamm/elexis/common/ui/cv/ArtikelstammCodeSelectorFactory.java
@@ -43,6 +43,7 @@ import ch.elexis.core.data.events.ElexisEventDispatcher;
 import ch.elexis.core.ui.UiDesk;
 //import ch.elexis.core.ui.actions.AddVerrechenbarContributionItem;
 import ch.elexis.core.ui.actions.FlatDataLoader;
+import ch.elexis.core.ui.actions.PersistentObjectLoader.QueryFilter;
 import ch.elexis.core.ui.actions.ScannerEvents;
 import ch.elexis.core.ui.actions.ToggleVerrechenbarFavoriteAction;
 import ch.elexis.core.ui.icons.Images;
@@ -110,10 +111,13 @@ public class ArtikelstammCodeSelectorFactory extends CodeSelectorFactory {
 		mppsa.setChecked(
 			CoreHub.globalCfg.get(MephaPrefferedProviderSorterAction.CFG_PREFER_MEPHA, false));
 		SupportedATCFilteringAction safa = new SupportedATCFilteringAction(fdl);
+		FilterBlackboxAction fiblabo = new FilterBlackboxAction(fdl);
 		
 		List<IAction> actionList = new ArrayList<>();
 		actionList.add(mppsa);
 		actionList.add(safa);
+		actionList.add(fiblabo);
+		
 		populateSelectorPanel(slp, fdl, actionList);
 		slp.addActions(actionList.toArray(new IAction[actionList.size()]));
 		

--- a/at.medevit.ch.artikelstamm.elexis.common/src/at/medevit/ch/artikelstamm/elexis/common/ui/cv/ArtikelstammFlatDataLoader.java
+++ b/at.medevit.ch.artikelstamm.elexis.common/src/at/medevit/ch/artikelstamm/elexis/common/ui/cv/ArtikelstammFlatDataLoader.java
@@ -24,6 +24,7 @@ import org.eclipse.jface.viewers.TableViewer;
 
 import at.medevit.atc_codes.ATCCode;
 import at.medevit.atc_codes.ATCCodeService;
+import at.medevit.ch.artikelstamm.BlackBoxReason;
 import at.medevit.ch.artikelstamm.elexis.common.internal.ATCCodeServiceConsumer;
 import at.medevit.ch.artikelstamm.elexis.common.preference.PreferenceConstants;
 import at.medevit.ch.artikelstamm.elexis.common.ui.provider.atccache.ATCCodeCache;
@@ -115,6 +116,7 @@ public class ArtikelstammFlatDataLoader extends FlatDataLoader implements IDoubl
 			return atcFilter != null;
 		}
 	}
+	
 	
 	@Override
 	public IStatus work(IProgressMonitor monitor, HashMap<String, Object> params){

--- a/at.medevit.ch.artikelstamm.elexis.common/src/at/medevit/ch/artikelstamm/elexis/common/ui/cv/FilterBlackboxAction.java
+++ b/at.medevit.ch.artikelstamm.elexis.common/src/at/medevit/ch/artikelstamm/elexis/common/ui/cv/FilterBlackboxAction.java
@@ -1,0 +1,57 @@
+package at.medevit.ch.artikelstamm.elexis.common.ui.cv;
+
+import org.eclipse.jface.action.Action;
+import org.eclipse.jface.resource.ImageDescriptor;
+import org.eclipse.swt.graphics.Image;
+import org.eclipse.wb.swt.ResourceManager;
+
+import at.medevit.ch.artikelstamm.BlackBoxReason;
+import ch.artikelstamm.elexis.common.ArtikelstammItem;
+import ch.elexis.core.ui.actions.PersistentObjectLoader.QueryFilter;
+import ch.elexis.core.ui.icons.Images;
+import ch.elexis.data.PersistentObject;
+import ch.elexis.data.Query;
+
+/**
+ * Filter blackboxed items out. 
+ * @see BlackBoxReason
+ * @author gerry
+ *
+ */
+public class FilterBlackboxAction extends Action {
+	ArtikelstammFlatDataLoader fdl;
+	BlackBoxQueryFilter bbqf;
+	private ImageDescriptor blackBoxedImage = ResourceManager.getPluginImageDescriptor("at.medevit.ch.artikelstamm.ui",
+			"/rsc/icons/flag-black.png");
+	
+	public FilterBlackboxAction(ArtikelstammFlatDataLoader fdl){
+		super("Backbox filtern",Action.AS_CHECK_BOX);
+		
+		setToolTipText("Nicht lieferbare Artikel ausblenden");
+		setImageDescriptor(blackBoxedImage);
+		this.fdl=fdl;
+		bbqf=new BlackBoxQueryFilter();
+		fdl.addQueryFilter(bbqf);
+		setChecked(false);
+	}
+	
+	@Override
+	public void run() {
+		if(isChecked()) {
+			fdl.removeQueryFilter(bbqf);
+			
+		}else {
+			fdl.addQueryFilter(bbqf);
+		}
+		fdl.changed(null);
+	}
+	private class BlackBoxQueryFilter implements QueryFilter{
+
+		@Override
+		public void apply(Query<? extends PersistentObject> qbe){
+			qbe.add(ArtikelstammItem.FLD_BLACKBOXED,Query.EQUALS,"0");
+			
+		}
+		
+	}
+}


### PR DESCRIPTION
After getting used a bit, I like the new article view. But I don't like that lots of blackboxed (i.e. unusable) articles are displayed by default. So I added a blackbox.Filter button to the view's toolbar. 
The logic is: Blackboxed articles are filtered by default, Only if the blackbox-toolbutton is active, they appear in the list.

![blackboxed](https://user-images.githubusercontent.com/3314994/34908168-f766a6f6-f88b-11e7-8cb4-13049e94bafa.png)

![unblackboxed](https://user-images.githubusercontent.com/3314994/34908181-315d6430-f88c-11e7-8212-1354363d1840.png)
  