### PR TITLE
Hilotec fixes 2018 jan #2

### DIFF
--- a/com.hilotec.elexis.messwerte.v2/src/com/hilotec/elexis/messwerte/v2/views/MessungenUebersichtV21.java
+++ b/com.hilotec.elexis.messwerte.v2/src/com/hilotec/elexis/messwerte/v2/views/MessungenUebersichtV21.java
@@ -57,6 +57,7 @@ import ch.elexis.core.ui.UiDesk;
 import ch.elexis.core.ui.icons.Images;
 import ch.elexis.core.ui.util.SWTHelper;
 import ch.elexis.core.ui.util.ViewMenus;
+import ch.elexis.data.Konsultation;
 import ch.elexis.data.Patient;
 import ch.rgw.tools.TimeTool;
 
@@ -106,16 +107,27 @@ public class MessungenUebersichtV21 extends ViewPart implements ElexisEventListe
 		}
 	};
 	
-	private void setCurPatient(Patient patient){
-		if (patient == null) {
-			form.setText(Messages.MessungenUebersicht_kein_Patient);
-		} else {
-			form.setText(patient.getLabel());
-		}
-		CTabItem tab = tabfolder.getSelection();
-		Control c = tab.getControl();
-		MessungTyp t = (MessungTyp) c.getData(DATA_TYP);
-		refreshContent(patient, t);
+	private void setCurPatient(final Patient patient){
+		Runnable runnable = new Runnable() {
+			public void run() {
+            //multithreading to avoid directly updating the UI which causes Illegal thread access
+				UiDesk.asyncExec(new Runnable() {
+					@Override
+					public void run(){
+						if (patient == null) {
+							form.setText(Messages.MessungenUebersicht_kein_Patient);
+						} else {
+							form.setText(patient.getLabel());
+						}
+						CTabItem tab = tabfolder.getSelection();
+						Control c = tab.getControl();
+						MessungTyp t = (MessungTyp) c.getData(DATA_TYP);
+						refreshContent(patient, t);
+					}
+				});     
+			}
+		};
+		new Thread(runnable).start();
 	}
 	
 	public void catchElexisEvent(final ElexisEvent ev){

--- a/com.hilotec.elexis.opendocument/.settings/org.eclipse.jdt.core.prefs
+++ b/com.hilotec.elexis.opendocument/.settings/org.eclipse.jdt.core.prefs
@@ -1,7 +1,7 @@
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.7
-org.eclipse.jdt.core.compiler.compliance=1.7
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
+org.eclipse.jdt.core.compiler.compliance=1.8
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
-org.eclipse.jdt.core.compiler.source=1.7
+org.eclipse.jdt.core.compiler.source=1.8


### PR DESCRIPTION
-    changed com.hilotec.elexis.opendocument plugin preferred java version from 1.7 to 1.8 (1.7 seems to be causing problems with earlier Java 1.7 versions during build). 1.8 Builds the plugin successfully
-     multi threading to avoid directly updating the UI which causes Illegal thread access in run() (same problem occurred in ArchivKG)
