### PR TITLE
Article substances

### DIFF
--- a/at.medevit.ch.artikelstamm.elexis.common/src/at/medevit/ch/artikelstamm/elexis/common/importer/ArtikelstammImporterPage.java
+++ b/at.medevit.ch.artikelstamm.elexis.common/src/at/medevit/ch/artikelstamm/elexis/common/importer/ArtikelstammImporterPage.java
@@ -18,6 +18,7 @@ import org.eclipse.core.runtime.IStatus;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
+import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Label;
 import org.slf4j.Logger;
@@ -30,11 +31,21 @@ import ch.elexis.core.ui.util.SWTHelper;
 
 public class ArtikelstammImporterPage extends ImporterPage {
 	private static Logger log = LoggerFactory.getLogger(ArtikelstammImporter.class);
+	private Button cbPharma;
+	private Button cbNonPharma;
+	private boolean bPharma;
+	private boolean bNonPharma;
 	
 	@Override
 	public IStatus doImport(IProgressMonitor monitor) throws Exception{
 		log.info("ArtikelstammImporterPage.doImport " + results[0]);
-		return ArtikelstammImporter.performImport(monitor, new FileInputStream(results[0]), null);
+		return ArtikelstammImporter.performImport(monitor, new FileInputStream(results[0]), bPharma, bNonPharma, null);
+	}
+	
+	@Override
+	public void collect() {
+		bPharma=cbPharma.getSelection();
+		bNonPharma=cbNonPharma.getSelection();
 	}
 	
 	@Override
@@ -67,6 +78,12 @@ public class ArtikelstammImporterPage extends ImporterPage {
 				.format(ArtikelstammItem.getImportSetCreationDate()));
 		}
 		lblVERSION.setText(sb.toString());
+		cbPharma = new Button(parent, SWT.CHECK);
+		cbPharma.setText("Pharma-Artikel");
+		cbPharma.setLayoutData(SWTHelper.getFillGridData(1, true, 1, true));
+		cbNonPharma = new Button(parent, SWT.CHECK);
+		cbNonPharma.setText("Non-Pharma-Artikel");
+		cbNonPharma.setLayoutData(SWTHelper.getFillGridData(1, true, 1, true));
 		
 		Composite ret = new ImporterPage.FileBasedImporter(parent, this);
 		ret.setLayoutData(SWTHelper.getFillGridData(1, true, 1, true));

--- a/at.medevit.ch.artikelstamm.elexis.common/src/at/medevit/ch/artikelstamm/elexis/common/ui/cv/ArtikelstammCodeSelectorFactory.java
+++ b/at.medevit.ch.artikelstamm.elexis.common/src/at/medevit/ch/artikelstamm/elexis/common/ui/cv/ArtikelstammCodeSelectorFactory.java
@@ -65,7 +65,8 @@ public class ArtikelstammCodeSelectorFactory extends CodeSelectorFactory {
 	private int eventType = SWT.KeyDown;
 	private ToggleVerrechenbarFavoriteAction tvfa = new ToggleVerrechenbarFavoriteAction();
 	
-	private static final String DISP_NAME = "Artikel oder Wirkstoff";
+	private static final String DISP_PRODNAME = "Artikel";
+	private static final String DISP_SUBSTANCE = "Substanz";
 	
 	private ISelectionChangedListener selChange = new ISelectionChangedListener() {
 		@Override
@@ -82,8 +83,9 @@ public class ArtikelstammCodeSelectorFactory extends CodeSelectorFactory {
 		cov.setSelectionChangedListener(selChange);
 		
 		FieldDescriptor<?>[] fields = {
-			new FieldDescriptor<ArtikelstammItem>(DISP_NAME, ArtikelstammItem.FLD_DSCR, Typ.STRING,
+			new FieldDescriptor<ArtikelstammItem>(DISP_PRODNAME, ArtikelstammItem.FLD_DSCR, Typ.STRING,
 				null),
+			new FieldDescriptor<ArtikelstammItem>(DISP_SUBSTANCE,ArtikelstammItem.FLD_SUBSTANCE, Typ.STRING,null)
 		};
 		
 		// add keyListener to search field
@@ -223,7 +225,7 @@ public class ArtikelstammCodeSelectorFactory extends CodeSelectorFactory {
 
 		@Override
 		public void changed(HashMap<String, String> values){
-			String val = values.get(DISP_NAME);
+			String val = values.get(DISP_PRODNAME);
 			if (val != null && val.length() == 13 && StringUtils.isNumeric(val)) {	
 				List<ArtikelstammItem> result = new Query<ArtikelstammItem>(ArtikelstammItem.class,
 					ArtikelstammItem.FLD_GTIN, val).execute();

--- a/at.medevit.ch.artikelstamm.elexis.common/src/at/medevit/ch/artikelstamm/elexis/common/ui/provider/ATCArtikelstammDecoratingLabelProvider.java
+++ b/at.medevit.ch.artikelstamm.elexis.common/src/at/medevit/ch/artikelstamm/elexis/common/ui/provider/ATCArtikelstammDecoratingLabelProvider.java
@@ -14,6 +14,7 @@ import at.medevit.ch.artikelstamm.ui.ATCLabelProvider;
 import ch.artikelstamm.elexis.common.ArtikelstammItem;
 import ch.elexis.core.data.activator.CoreHub;
 import ch.elexis.core.data.interfaces.IVerrechenbar.VatInfo;
+import ch.rgw.tools.StringTool;
 
 public class ATCArtikelstammDecoratingLabelProvider extends DecoratingLabelProvider {
 	
@@ -42,6 +43,10 @@ public class ATCArtikelstammDecoratingLabelProvider extends DecoratingLabelProvi
 				if (publicPrice > 0.0d) {
 					ret = ret + " <" + ai.getPublicPrice() + "> ";
 				}
+			}
+			String subst=ai.get(ArtikelstammItem.FLD_SUBSTANCE);
+			if(!StringTool.isNothing(subst)) {
+				ret=ret+" ("+subst+")";
 			}
 			
 			return ret;

--- a/at.medevit.ch.artikelstamm.elexis.common/src/ch/artikelstamm/elexis/common/ArtikelstammItem.java
+++ b/at.medevit.ch.artikelstamm.elexis.common/src/ch/artikelstamm/elexis/common/ArtikelstammItem.java
@@ -86,6 +86,7 @@ public class ArtikelstammItem extends Artikel implements IArtikelstammItem {
 	/** CAS Nr wenn Betäub */	public static final String FLD_NARCOTIC_CAS = "NARCOTIC_CAS";
 	/** Ist Impfstoff */		public static final String FLD_VACCINE = "VACCINE";
 	/** Produkt-Nummer */ 	  	public static final String FLD_PRODNO = "PRODNO";
+	/** Substance(s) */			public static final String FLD_SUBSTANCE="SUBSTANCE";
 	
 	public static final String EXTINFO_VAL_VAT_OVERRIDEN = "VAT_OVERRIDE";
 	public static final String EXTINFO_VAL_PPUB_OVERRIDE_STORE ="PPUB_OVERRIDE_STORE";
@@ -125,6 +126,7 @@ public class ArtikelstammItem extends Artikel implements IArtikelstammItem {
 			+ FLD_VACCINE + " CHAR(1),"
 			+ VERKAUFSEINHEIT + " VARCHAR(4),"  // Stück pro Abgabe
 			+ FLD_PRODNO+" VARCHAR(10),"
+			+ FLD_SUBSTANCE+" VARCHAR(255),"	// Substanz(en)
 			+ PersistentObject.FLD_EXTINFO + " BLOB"
 			+ "); "
 			+ "CREATE INDEX idxAiPHAR ON " + TABLENAME + " ("+FLD_PHAR+"); "

--- a/at.medevit.ch.artikelstamm.elexis.common/whatisit.textile
+++ b/at.medevit.ch.artikelstamm.elexis.common/whatisit.textile
@@ -16,3 +16,15 @@ Die Open-Source Variante ist komplett frei zur Verwendung. Informationen dazu, d
 h2. Sponsor
 
 The development of this plugin was sponsored by Dr. med. Franz Marty, "Medizinisches Zentrum, gleis d":http://www.mez-chur.com/ 
+
+
+h2. Erweiterung "article substances"
+
+Dieser Patch 
+
+- Ergänzt die Tabelle artikelstamm_ch um eie Spalte "substance"
+- Befüllt diese Spalte beim Import anhand des ATC Codes
+- Erstellt einen neuen Textfilter in der Artikel-View, die nach Substanzen filtern kann
+
+G. Weirich 2018
+ 

--- a/at.medevit.ch.artikelstamm/src-gen/at/medevit/ch/artikelstamm/ARTIKELSTAMM.java
+++ b/at.medevit.ch.artikelstamm/src-gen/at/medevit/ch/artikelstamm/ARTIKELSTAMM.java
@@ -1811,7 +1811,7 @@ public class ARTIKELSTAMM {
              *     {@link String }
              *     
              */
-            public String getATC() {
+			public String getATC() {
                 return atc;
             }
 


### PR DESCRIPTION
This PR does the following:

* Adds a new column "SUBSTANCE" to artikelstamm_ch.
* Populates this column on import with names from the ATC Code.
* Allows to import selectively Pharma, Non-Pharma or both kinds of articles.
* Adds a filter field "Substance" to the Artikel-Selector to make it possible to filter articles by substance. e.g. "diclofenac" will find arthrotec, olfen, voltaren and so on.
* Modifies the LabelProvider for the Artikel-Selector so it shows substance names where given.
* Adds checks for "cancel" to the import process to enable the user to interrupt this lengthy procedure (with the risk of possibly invalid data of course)

Note: Filtering for substances works only after the next import of the "Artikelstamm" after installing, since the field "SUBSTANCE" is populated during import.

![artikel_2](https://user-images.githubusercontent.com/3314994/35844886-0d302d40-0b10-11e8-9e0c-df93ccc8f8f0.jpg)
