### PR TITLE
percent positions counter bug

### DIFF
--- a/ch.elexis.base.ch.arzttarife/src/ch/elexis/data/TarmedOptifier.java
+++ b/ch.elexis.base.ch.arzttarife/src/ch/elexis/data/TarmedOptifier.java
@@ -209,7 +209,9 @@ public class TarmedOptifier implements IOptifier {
 			if (v.isInstance(code)) {
 				if (!tc.requiresSide()) {
 					newVerrechnet = v;
-					newVerrechnet.setZahl(newVerrechnet.getZahl() + 1);
+					if (!(",00.2530,00.2570,00.2550,00.2590,04.0620,04.1930,06.0430,06.0440,06.0730,06.0740,07.0300,24.0250,24.3250,28.0020,"
+							.contains("," + code.getCode())))
+						newVerrechnet.setZahl(newVerrechnet.getZahl() + 1);
 					break;
 				}
 			}


### PR DESCRIPTION
Hurra - habe einen Pull-Request hingekriegt

Siehe Issue "Tarmed - Prozent-Positionen können mehrfach addiert werden"
Die Liste der betreffenden Positionen sind direkt als String im Code.
Könnte man natürlich auch schöner zentral definieren - tut Euch keinen Zwang an... ;-)

Wenn die entsprechende Prozent-Position schon vorhanden ist, wird einfach der Counter für newVerrechnet NICHT hochgezählt - die Methode läuft aber normal weiter, und die Positionen werden korrekt neu durchgerechnet.
