### PR TITLE
Fix Bundle-Classpath and build properties of ch.itmed.lmz.risch.laborder

### DIFF
--- a/bundles/ch.itmed.lmz.risch.laborder/META-INF/MANIFEST.MF
+++ b/bundles/ch.itmed.lmz.risch.laborder/META-INF/MANIFEST.MF
@@ -12,6 +12,4 @@ Require-Bundle: ch.elexis.core.data;bundle-version="3.6.0",
  org.eclipse.ui;bundle-version="3.109.0",
  org.eclipse.core.runtime;bundle-version="3.13.0",
  com.google.code.gson;bundle-version="2.8.0"
-Bundle-ClassPath: lib/gson-2.8.5.jar,
- .
 Bundle-ActivationPolicy: lazy

--- a/bundles/ch.itmed.lmz.risch.laborder/build.properties
+++ b/bundles/ch.itmed.lmz.risch.laborder/build.properties
@@ -1,7 +1,6 @@
 source.. = src/
 output.. = bin/
-bin.includes = META-INF/,\
-               .,\
-               lib/,\
+bin.includes = .,\
                rsc/,\
-               lib/gson-2.8.5.jar
+               META-INF/,\
+               plugin.xml


### PR DESCRIPTION
Beim Wechsel auf die Target-Version von gson wurden die Build Properties und der Bundle-Classpath nicht angepasst. Für die Anpassungen wurde ein neuer Branch erstellt, um keine Merge-Konflikte zu provozieren.