### PR TITLE
 Use command in TerminDialog print logic

### DIFF
--- a/bundles/ch.elexis.agenda/plugin.xml
+++ b/bundles/ch.elexis.agenda/plugin.xml
@@ -122,6 +122,11 @@
                id="ch.elexis.agenda.commands.SortDescending"
                name="%SortDescending">
          </command>
+         <command
+               id="ch.elexis.agenda.commands.printAppointmentLabel"
+               categoryId="ch.elexis.agenda.commands"
+               defaultHandler="ch.elexis.agenda.commands.PrintAppointmentLabelHandler">
+         </command>
       </extension>
       <extension
             point="org.eclipse.ui.menus">

--- a/bundles/ch.elexis.agenda/src/ch/elexis/agenda/commands/PrintAppointmentLabelHandler.java
+++ b/bundles/ch.elexis.agenda/src/ch/elexis/agenda/commands/PrintAppointmentLabelHandler.java
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IT-Med AG <info@it-med-ag.ch>.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IT-Med AG <info@it-med-ag.ch> - initial implementation
+ ******************************************************************************/
+
+package ch.elexis.agenda.commands;
+
+import java.util.ArrayList;
+
+import org.eclipse.core.commands.AbstractHandler;
+import org.eclipse.core.commands.ExecutionEvent;
+import org.eclipse.core.commands.ExecutionException;
+import org.eclipse.ui.PlatformUI;
+
+import ch.elexis.agenda.data.Termin;
+import ch.elexis.dialogs.TermineDruckenDialog;
+
+public final class PrintAppointmentLabelHandler extends AbstractHandler {
+	private static ArrayList<Termin> lTermine;
+	
+	/**
+	 * Adds a list of Termine for print processing.
+	 * @param termine
+	 */
+	public static void setTermine(ArrayList<Termin> termine) {
+		lTermine = termine;
+	}
+
+	@Override
+	public Object execute(ExecutionEvent event) throws ExecutionException {
+		new TermineDruckenDialog(PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell(), lTermine.toArray(new Termin[0])).open();
+		
+		return null;
+	}
+
+}


### PR DESCRIPTION
Using the Eclipse Platform Command Framework in the TerminDialog print logic allows us to replace the default handler with a custom one. This change provides more flexibility for the print handling of the appointments.