### PR TITLE
[24534] Add test for changed ATCcode in Artikelstammimport

### DIFF
--- a/tests/at.medevit.ch.artikelstamm.model.test/rsc/artikelstamm_first_v5.xml
+++ b/tests/at.medevit.ch.artikelstamm.model.test/rsc/artikelstamm_first_v5.xml
@@ -2,6 +2,16 @@
 <ARTIKELSTAMM xmlns="http://elexis.ch/Elexis_Artikelstamm_v5" CREATION_DATETIME="2017-12-25T00:00:00.000+01:00" BUILD_DATETIME="2017-12-25T00:00:00.000+01:00" DATA_SOURCE="oddb2xml">
     <PRODUCTS>
         <PRODUCT>
+            <PRODNO>5815801</PRODNO>
+            <SALECD>A</SALECD>
+            <DSCR>Priorix Tetra Trockensub c Solv</DSCR>
+            <DSCRF>Priorix Tetra subst sèche c solv</DSCRF>
+            <DSCRI>Priorix Tetra Trockensub c Solv</DSCRI>
+            <ATC>J07BD53</ATC>
+            <LIMNAMEBAG>0808</LIMNAMEBAG>
+            <SUBSTANCE>Verschiedene Kombinationen</SUBSTANCE>
+        </PRODUCT>
+        <PRODUCT>
             <PRODNO>2848601</PRODNO>
             <SALECD>A</SALECD>
             <DSCR>Ancopir Inj Lös</DSCR>

--- a/tests/at.medevit.ch.artikelstamm.model.test/src/at/medevit/ch/artikelstamm/model/importer/ArtikelstammImporterTest.java
+++ b/tests/at.medevit.ch.artikelstamm.model.test/src/at/medevit/ch/artikelstamm/model/importer/ArtikelstammImporterTest.java
@@ -44,6 +44,8 @@ public class ArtikelstammImporterTest {
 	private static final String gtinUserPrice = "7680273040281";
 	private static final String gtin14chars = "68711428066649";
 	private static final String gtinPriorix = "7680581580011";
+	private static final String atcPriorixFirst = "J07BD53";
+	private static final String atcPriorixSecond = "J07BD54";
 	private static final String gtinNonPharma = "68711428066649";
 	private static final String[] slEntries = new String[] { "7680273040281", "7680651600014" };
 	private static final int OLD_PKG_SIZE = 448;
@@ -189,6 +191,12 @@ public class ArtikelstammImporterTest {
 		assertEquals(gtinWithPriceOverridden, ((IArtikelstammItem) item7digitPhar.get()).getGtin());
 		assertEquals(pharWithPriceOverridden, ((IArtikelstammItem) item7digitPhar.get()).getPHAR());
 
+		// Test ATC-Code from first import
+		Optional<ICodeElement> priorix = artikelstammCodeElements.loadFromCode(gtinPriorix, Collections.emptyMap());
+		log.debug(String.format("priorix gtin first  import %s atc %s", ((IArtikelstammItem) priorix.get()).getGtin(),
+				((IArtikelstammItem) priorix.get()).getAtcCode()));
+		assertEquals(atcPriorixFirst, ((IArtikelstammItem) priorix.get()).getAtcCode());
+
 		setPkgOverride(gtinWithPkgSizeOverride);
 		setPkgOverride(gtinWithPkgSizeOverrideNull);
 
@@ -200,6 +208,12 @@ public class ArtikelstammImporterTest {
 			fail(msg);
 		}
 		log.debug("testImportAlreadyOkay second done");
+
+		// Test ATC-Code from first import
+		priorix = artikelstammCodeElements.loadFromCode(gtinPriorix, Collections.emptyMap());
+		log.debug(String.format("priorix gtin second import %s atc %s", ((IArtikelstammItem) priorix.get()).getGtin(),
+				((IArtikelstammItem) priorix.get()).getAtcCode()));
+		assertEquals(atcPriorixSecond, ((IArtikelstammItem) priorix.get()).getAtcCode());
 
 		// Check a new article not present in first
 		assertTrue(artikelstammCodeElements.loadFromCode(gtinOnlyInSecond).isPresent());


### PR DESCRIPTION
What is NOT tested is the atcCodeCacheService as on line 206 of ArtikelstammImporter.java  the rebuildCache is not called when in testMode! 