### PR TITLE
[26233] More adaptions for the LG1<->medicalvalues order plugin

### DIFF
--- a/bundles/ch.elexis.labororder.lg1_medicalvalues/readme.md
+++ b/bundles/ch.elexis.labororder.lg1_medicalvalues/readme.md
@@ -16,19 +16,14 @@ The button simply shows the LG1 logo.
 To trigger the order creation via the button, a patient and an encounter must be selected and the following data must be
 present:
 
-- User
-  - EAN number
-  - KSK/ZSR number
 - Patient
   - First name
   - last name
   - birthdate
   - gender
-  - social security number (AHV)
 - Encounter (Fall)
   - Invoice Recipient
   - Cost Bearer
-    - EAN number
     - Name
     - Street and number
     - ZIP Code


### PR DESCRIPTION
We decided to soften up the stricktness of our api call regarding the required parameters.

- make all `Xids` optional
- fix some queryParamerter typos
- determine billing types our services use via `BillingLaw`, not the costBearer