### PR TITLE
[26624] laborimport labtop

### DIFF
--- a/bundles/ch.elexis.laborimport_labtop/src/ch/elexis/laborimport/labtop/Importer.java
+++ b/bundles/ch.elexis.laborimport_labtop/src/ch/elexis/laborimport/labtop/Importer.java
@@ -113,10 +113,6 @@ public class Importer extends ImporterPage {
 	}
 
 	private Result<?> importDirect() {
-		if (openmedicalObject == null) {
-			SWTHelper.showInfo("Laborimport",
-					"Fehlerhafte OpenMedical Konfiguration. Direktimport aus Downloadverzeichnis wird ausgeführt.");
-		}
 		Result<String> result = new Result<String>("OK");
 
 		String downloadDirPath = CoreHub.localCfg.get(PreferencePage.DL_DIR, CoreHub.getTempDir().toString());
@@ -139,10 +135,9 @@ public class Importer extends ImporterPage {
 			} catch (Throwable e) {
 				// method call failed; do nothing
 			}
-		} else {
-			res = 0;
 		}
 		// if (res > 0) {
+		res = 0;
 		File downloadDir = new File(downloadDirPath);
 		if (downloadDir.isDirectory()) {
 			File archiveDir = new File(downloadDir, "archive");
@@ -166,7 +161,7 @@ public class Importer extends ImporterPage {
 				try {
 					rs = hlp.importFile(f, archiveDir, false);
 					if (openmedicalObject == null) {
-						res += 1;
+						res++;
 					}
 				} catch (IOException e) {
 					SWTHelper.showError("Import error", e.getMessage());

--- a/bundles/ch.elexis.laborimport_labtop/src/ch/elexis/laborimport/labtop/Importer.java
+++ b/bundles/ch.elexis.laborimport_labtop/src/ch/elexis/laborimport/labtop/Importer.java
@@ -196,7 +196,31 @@ public class Importer extends ImporterPage {
 			String filename = results[1];
 			return ResultAdapter.getResultAsStatus(hlp.importFile(filename, false));
 		} else {
-			return ResultAdapter.getResultAsStatus(importDirect());
+			if (openmedicalObject != null) {
+				return ResultAdapter.getResultAsStatus(importDirect());
+			} else {
+				File downloadPath = new File(CoreHub.localCfg.get(PreferencePage.DL_DIR, null));
+				File archiveDir = new File(downloadPath, "archive"); //$NON-NLS-1$
+				String[] files = downloadPath.list(new FilenameFilter() {
+					@Override
+					public boolean accept(File path, String name) {
+						if (name.toLowerCase().endsWith(".hl7")) { //$NON-NLS-1$
+							return true;
+						}
+						return false;
+					}
+				});
+				Result<?> rs = null;
+				for (String file : files) {
+					File f = new File(downloadPath, file);
+					try {
+						rs = hlp.importFile(f, archiveDir, false);
+					} catch (IOException e) {
+						SWTHelper.showError("Import error", e.getMessage()); //$NON-NLS-1$
+					}
+				}
+				return ResultAdapter.getResultAsStatus(rs);
+			}
 		}
 	}
 
@@ -290,10 +314,6 @@ public class Importer extends ImporterPage {
 
 				home.results[0] = new Integer(DIRECT).toString();
 				home.results[1] = StringUtils.EMPTY;
-			}
-
-			if (openmedicalObject == null) {
-				bDirect.setEnabled(false);
 			}
 
 			SelectionAdapter sa = new SelectionAdapter() {

--- a/bundles/ch.elexis.laborimport_labtop/src/ch/elexis/laborimport/labtop/PreferencePage.java
+++ b/bundles/ch.elexis.laborimport_labtop/src/ch/elexis/laborimport/labtop/PreferencePage.java
@@ -16,10 +16,18 @@ package ch.elexis.laborimport.labtop;
 import org.eclipse.jface.preference.DirectoryFieldEditor;
 import org.eclipse.jface.preference.FieldEditorPreferencePage;
 import org.eclipse.jface.preference.FileFieldEditor;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.events.SelectionAdapter;
+import org.eclipse.swt.events.SelectionEvent;
+import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.layout.GridLayout;
+import org.eclipse.swt.widgets.Button;
+import org.eclipse.swt.widgets.Composite;
 import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchPreferencePage;
 
 import ch.elexis.core.data.activator.CoreHub;
+import ch.elexis.core.services.holder.ConfigServiceHolder;
 import ch.elexis.core.ui.preferences.SettingsPreferenceStore;
 
 public class PreferencePage extends FieldEditorPreferencePage implements IWorkbenchPreferencePage {
@@ -27,6 +35,11 @@ public class PreferencePage extends FieldEditorPreferencePage implements IWorkbe
 	public static final String JAR_PATH = "labtop/jar_path"; //$NON-NLS-1$
 	public static final String INI_PATH = "labtop/ini_path"; //$NON-NLS-1$
 	public static final String DL_DIR = "labtop/downloaddir"; //$NON-NLS-1$
+	public static final String ON = "OpenMedical aus"; //$NON-NLS-1$
+	public static final String OFF = "OpenMedical an"; //$NON-NLS-1$
+	public static final String CFG_OPENMEDICAL = "labtop/openmedical"; //$NON-NLS-1$
+
+	private boolean openMedical = false;
 
 	public PreferencePage() {
 		super(GRID);
@@ -35,12 +48,59 @@ public class PreferencePage extends FieldEditorPreferencePage implements IWorkbe
 
 	@Override
 	protected void createFieldEditors() {
-		addField(new FileFieldEditor(JAR_PATH, Messages.PreferencePage_JMedTrasferJar, getFieldEditorParent()));
-		addField(new FileFieldEditor(INI_PATH, Messages.PreferencePage_JMedTrasferJni, getFieldEditorParent()));
+		Button button = new Button(getFieldEditorParent(), SWT.PUSH | SWT.CENTER);
+		GridData gridData = new GridData(SWT.LEFT, SWT.TOP, false, false);
+		gridData.horizontalSpan = 3;
+		button.setLayoutData(gridData);
+		Composite container = createContainer(getFieldEditorParent());
+
+		addField(new FileFieldEditor(JAR_PATH, Messages.PreferencePage_JMedTrasferJar, container));
+		addField(new FileFieldEditor(INI_PATH, Messages.PreferencePage_JMedTrasferJni, container));
 		addField(new DirectoryFieldEditor(DL_DIR, Messages.PreferencePage_DownloadDir, getFieldEditorParent()));
+
+		setBoolean(button);
+		toggleExclude(container);
+		setBtnText(button);
+		button.addSelectionListener(new SelectionAdapter() {
+			@Override
+			public void widgetSelected(SelectionEvent e) {
+				toggleOpenMedical();
+				toggleExclude(container);
+				setBtnText(button);
+			}
+		});
 	}
 
 	public void init(final IWorkbench workbench) {
 		// TODO Auto-generated method stub
+	}
+
+	private Composite createContainer(Composite parent) {
+		Composite container = new Composite(parent, SWT.NONE);
+		container.setLayout(new GridLayout());
+		GridData gridData = new GridData(SWT.FILL, SWT.CENTER, true, false);
+		gridData.horizontalSpan = 3;
+		container.setLayoutData(gridData);
+		return container;
+	}
+
+	private void toggleExclude(Composite container) {
+		container.setVisible(!openMedical);
+		((GridData) container.getLayoutData()).exclude = openMedical;
+		getFieldEditorParent().layout(true, true);
+	}
+
+	private void toggleOpenMedical() {
+		ConfigServiceHolder.get().set(CFG_OPENMEDICAL, openMedical);
+		openMedical = !openMedical;
+	}
+
+	private void setBtnText(Button btn) {
+		btn.setText(openMedical ? OFF : ON);
+		btn.setSize(99, 25);
+	}
+
+	private void setBoolean(Button btn) {
+		openMedical = !ConfigServiceHolder.get().get(CFG_OPENMEDICAL, false);
 	}
 }

--- a/bundles/ch.elexis.laborimport_labtop/src/ch/elexis/laborimport/labtop/PreferencePage.java
+++ b/bundles/ch.elexis.laborimport_labtop/src/ch/elexis/laborimport/labtop/PreferencePage.java
@@ -16,18 +16,10 @@ package ch.elexis.laborimport.labtop;
 import org.eclipse.jface.preference.DirectoryFieldEditor;
 import org.eclipse.jface.preference.FieldEditorPreferencePage;
 import org.eclipse.jface.preference.FileFieldEditor;
-import org.eclipse.swt.SWT;
-import org.eclipse.swt.events.SelectionAdapter;
-import org.eclipse.swt.events.SelectionEvent;
-import org.eclipse.swt.layout.GridData;
-import org.eclipse.swt.layout.GridLayout;
-import org.eclipse.swt.widgets.Button;
-import org.eclipse.swt.widgets.Composite;
 import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchPreferencePage;
 
 import ch.elexis.core.data.activator.CoreHub;
-import ch.elexis.core.services.holder.ConfigServiceHolder;
 import ch.elexis.core.ui.preferences.SettingsPreferenceStore;
 
 public class PreferencePage extends FieldEditorPreferencePage implements IWorkbenchPreferencePage {
@@ -35,11 +27,6 @@ public class PreferencePage extends FieldEditorPreferencePage implements IWorkbe
 	public static final String JAR_PATH = "labtop/jar_path"; //$NON-NLS-1$
 	public static final String INI_PATH = "labtop/ini_path"; //$NON-NLS-1$
 	public static final String DL_DIR = "labtop/downloaddir"; //$NON-NLS-1$
-	public static final String ON = "OpenMedical aus"; //$NON-NLS-1$
-	public static final String OFF = "OpenMedical an"; //$NON-NLS-1$
-	public static final String CFG_OPENMEDICAL = "labtop/openmedical"; //$NON-NLS-1$
-
-	private boolean openMedical = false;
 
 	public PreferencePage() {
 		super(GRID);
@@ -48,59 +35,22 @@ public class PreferencePage extends FieldEditorPreferencePage implements IWorkbe
 
 	@Override
 	protected void createFieldEditors() {
-		Button button = new Button(getFieldEditorParent(), SWT.PUSH | SWT.CENTER);
-		GridData gridData = new GridData(SWT.LEFT, SWT.TOP, false, false);
-		gridData.horizontalSpan = 3;
-		button.setLayoutData(gridData);
-		Composite container = createContainer(getFieldEditorParent());
+		FileFieldEditor jarEditor = new FileFieldEditor(JAR_PATH, Messages.PreferencePage_JMedTrasferJar,
+				getFieldEditorParent());
+		FileFieldEditor iniEditor = new FileFieldEditor(INI_PATH, Messages.PreferencePage_JMedTrasferJni,
+				getFieldEditorParent());
+		DirectoryFieldEditor dirEditor = new DirectoryFieldEditor(DL_DIR, Messages.PreferencePage_DownloadDir,
+				getFieldEditorParent());
 
-		addField(new FileFieldEditor(JAR_PATH, Messages.PreferencePage_JMedTrasferJar, container));
-		addField(new FileFieldEditor(INI_PATH, Messages.PreferencePage_JMedTrasferJni, container));
-		addField(new DirectoryFieldEditor(DL_DIR, Messages.PreferencePage_DownloadDir, getFieldEditorParent()));
+		jarEditor.getTextControl(getFieldEditorParent()).setMessage("Optional"); //$NON-NLS-1$
+		iniEditor.getTextControl(getFieldEditorParent()).setMessage("Optional"); //$NON-NLS-1$
 
-		setBoolean(button);
-		toggleExclude(container);
-		setBtnText(button);
-		button.addSelectionListener(new SelectionAdapter() {
-			@Override
-			public void widgetSelected(SelectionEvent e) {
-				toggleOpenMedical();
-				toggleExclude(container);
-				setBtnText(button);
-			}
-		});
+		addField(jarEditor);
+		addField(iniEditor);
+		addField(dirEditor);
 	}
 
 	public void init(final IWorkbench workbench) {
 		// TODO Auto-generated method stub
-	}
-
-	private Composite createContainer(Composite parent) {
-		Composite container = new Composite(parent, SWT.NONE);
-		container.setLayout(new GridLayout());
-		GridData gridData = new GridData(SWT.FILL, SWT.CENTER, true, false);
-		gridData.horizontalSpan = 3;
-		container.setLayoutData(gridData);
-		return container;
-	}
-
-	private void toggleExclude(Composite container) {
-		container.setVisible(!openMedical);
-		((GridData) container.getLayoutData()).exclude = openMedical;
-		getFieldEditorParent().layout(true, true);
-	}
-
-	private void toggleOpenMedical() {
-		ConfigServiceHolder.get().set(CFG_OPENMEDICAL, openMedical);
-		openMedical = !openMedical;
-	}
-
-	private void setBtnText(Button btn) {
-		btn.setText(openMedical ? OFF : ON);
-		btn.setSize(99, 25);
-	}
-
-	private void setBoolean(Button btn) {
-		openMedical = !ConfigServiceHolder.get().get(CFG_OPENMEDICAL, false);
 	}
 }


### PR DESCRIPTION
my approach in adding a button to toggle the visibility of the jmedtransfer configuration fields in the laborimport preferencepage.
- I add a button which toggles the visibility of a container which contains the two jmedtransfer fields.
- I also add a boolean which saves the state in the 'config' table.

In the second commit 'directimport' I:
- removed the disabling of the radioButton if openMedical is null.
- added a directimport of .hl7 files in the download dir from pref page.