### PR TITLE
[26624] error handling when importing

### DIFF
--- a/bundles/ch.elexis.laborimport_labtop/src/ch/elexis/laborimport/labtop/Importer.java
+++ b/bundles/ch.elexis.laborimport_labtop/src/ch/elexis/laborimport/labtop/Importer.java
@@ -160,7 +160,9 @@ public class Importer extends ImporterPage {
 				Result<?> rs;
 				try {
 					rs = hlp.importFile(f, archiveDir, false);
-					if (openmedicalObject == null) {
+					if (rs.getSeverity().equals(Result.SEVERITY.ERROR)) {
+						throw new IOException(rs.getMessages().toString());
+					} else {
 						res++;
 					}
 				} catch (IOException e) {


### PR DESCRIPTION
- openmedical check fürs res increment entfernt.
- prüft ob beim importFile ein error vorkommt und throwt diesen wenn ja.