### PR TITLE
[26624] openmedical changes of importers

### DIFF
--- a/bundles/ch.elexis.laborimport.bioanalytica/src/ch/elexis/laborimport/bioanalytica/Importer.java
+++ b/bundles/ch.elexis.laborimport.bioanalytica/src/ch/elexis/laborimport/bioanalytica/Importer.java
@@ -121,16 +121,13 @@ public class Importer extends ImporterPage {
 	}
 
 	private Result importDirect() {
-		if (openmedicalObject == null) {
-			return new Result<String>(Result.SEVERITY.ERROR, 1, MY_LAB, "Fehlerhafte Konfiguration", true);
-		}
 		Result<String> result = new Result<String>("OK");
 
 		String downloadDirPath = CoreHub.localCfg.get(PreferencePage.DL_DIR, CoreHub.getTempDir().toString());
 		String iniPath = CoreHub.localCfg.get(PreferencePage.INI_PATH, null);
 
 		int res = -1;
-		if (iniPath != null) {
+		if (openmedicalObject != null && iniPath != null) {
 			try {
 				Object omResult = openmedicalDownloadMethod.invoke(openmedicalObject,
 						new Object[] { new String[] { "--download", downloadDirPath, "--logPath", downloadDirPath,
@@ -148,6 +145,7 @@ public class Importer extends ImporterPage {
 			}
 		}
 		// if (res > 0) {
+		res = 0;
 		File downloadDir = new File(downloadDirPath);
 		if (downloadDir.isDirectory()) {
 			File archiveDir = new File(downloadDir, "archive");
@@ -165,14 +163,23 @@ public class Importer extends ImporterPage {
 					return false;
 				}
 			});
+			Result<String> errors = new Result<>();
 			for (String file : files) {
 				File f = new File(downloadDir, file);
 				Result rs;
 				try {
 					rs = hlp.importFile(f, archiveDir, false);
+					if (rs.isOK()) {
+						res++;
+					} else {
+						errors.addMessage(rs.getSeverity(), f.getName() + ": " + rs.getCombinedMessages()); //$NON-NLS-1$
+					}
 				} catch (IOException e) {
 					SWTHelper.showError("Import error", e.getMessage());
 				}
+			}
+			if (!errors.isOK()) {
+				SWTHelper.showInfo("Fehler beim Import", errors.getCombinedMessages().replace(", ", "\r\n"));
 			}
 			SWTHelper.showInfo("Verbindung mit Labor " + MY_LAB + " erfolgreich",
 					"Es wurden " + Integer.toString(res) + " Dateien verarbeitet");
@@ -300,10 +307,6 @@ public class Importer extends ImporterPage {
 
 				home.results[0] = new Integer(DIRECT).toString();
 				home.results[1] = StringUtils.EMPTY;
-			}
-
-			if (openmedicalObject == null) {
-				bDirect.setEnabled(false);
 			}
 
 			SelectionAdapter sa = new SelectionAdapter() {

--- a/bundles/ch.elexis.laborimport.bioanalytica/src/ch/elexis/laborimport/bioanalytica/Messages.java
+++ b/bundles/ch.elexis.laborimport.bioanalytica/src/ch/elexis/laborimport/bioanalytica/Messages.java
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) 2007-2010, G. Weirich and Elexis
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     G. Weirich - initial API and implementation
+ * All the rest is done generically. See plug-in elexis-importer.
+ *
+ */
+package ch.elexis.laborimport.bioanalytica;
+
+public class Messages {
+	public static String PreferencePage_DownloadDir = ch.elexis.core.l10n.Messages.Core_Download_Directory;
+	public static String PreferencePage_JMedTrasferJar = ch.elexis.core.l10n.Messages.PreferencePage_JMedTrasferJar;
+	public static String PreferencePage_JMedTrasferJni = ch.elexis.core.l10n.Messages.PreferencePage_JMedTrasferJni;
+
+}

--- a/bundles/ch.elexis.laborimport.bioanalytica/src/ch/elexis/laborimport/bioanalytica/PreferencePage.java
+++ b/bundles/ch.elexis.laborimport.bioanalytica/src/ch/elexis/laborimport/bioanalytica/PreferencePage.java
@@ -23,9 +23,9 @@ import ch.elexis.core.ui.preferences.SettingsPreferenceStore;
 
 public class PreferencePage extends FieldEditorPreferencePage implements IWorkbenchPreferencePage {
 
-	public static final String JAR_PATH = "bioanalytica/jar_path";
-	public static final String INI_PATH = "bioanalytica/ini_path";
-	public static final String DL_DIR = "bioanalytica/downloaddir";
+	public static final String JAR_PATH = "bioanalytica/jar_path"; //$NON-NLS-1$
+	public static final String INI_PATH = "bioanalytica/ini_path"; //$NON-NLS-1$
+	public static final String DL_DIR = "bioanalytica/downloaddir"; //$NON-NLS-1$
 
 	public PreferencePage() {
 		super(GRID);
@@ -34,9 +34,19 @@ public class PreferencePage extends FieldEditorPreferencePage implements IWorkbe
 
 	@Override
 	protected void createFieldEditors() {
-		addField(new FileFieldEditor(JAR_PATH, "OpenMedical Bibliothek (JMedTransferO.jar)", getFieldEditorParent()));
-		addField(new FileFieldEditor(INI_PATH, "OpenMedical Konfiguration (MedTransfer.ini)", getFieldEditorParent()));
-		addField(new DirectoryFieldEditor(DL_DIR, "Download Verzeichnis", getFieldEditorParent()));
+		FileFieldEditor jarEditor = new FileFieldEditor(JAR_PATH, Messages.PreferencePage_JMedTrasferJar,
+				getFieldEditorParent());
+		FileFieldEditor iniEditor = new FileFieldEditor(INI_PATH, Messages.PreferencePage_JMedTrasferJni,
+				getFieldEditorParent());
+		DirectoryFieldEditor dirEditor = new DirectoryFieldEditor(DL_DIR, Messages.PreferencePage_DownloadDir,
+				getFieldEditorParent());
+
+		jarEditor.getTextControl(getFieldEditorParent()).setMessage("Optional");//$NON-NLS-1$
+		iniEditor.getTextControl(getFieldEditorParent()).setMessage("Optional");//$NON-NLS-1$
+
+		addField(jarEditor);
+		addField(iniEditor);
+		addField(dirEditor);
 	}
 
 	public void init(IWorkbench workbench) {

--- a/bundles/ch.elexis.laborimport.synlab/src/ch/elexis/laborimport/synlab/PreferencePage.java
+++ b/bundles/ch.elexis.laborimport.synlab/src/ch/elexis/laborimport/synlab/PreferencePage.java
@@ -32,9 +32,19 @@ public class PreferencePage extends FieldEditorPreferencePage implements IWorkbe
 
 	@Override
 	protected void createFieldEditors() {
-		addField(new FileFieldEditor(JAR_PATH, Messages.PreferencePage_JMedTrasferJar, getFieldEditorParent()));
-		addField(new FileFieldEditor(INI_PATH, Messages.PreferencePage_JMedTrasferJni, getFieldEditorParent()));
-		addField(new DirectoryFieldEditor(DL_DIR, Messages.PreferencePage_DownloadDir, getFieldEditorParent()));
+		FileFieldEditor jarEditor = new FileFieldEditor(JAR_PATH, Messages.PreferencePage_JMedTrasferJar,
+				getFieldEditorParent());
+		FileFieldEditor iniEditor = new FileFieldEditor(INI_PATH, Messages.PreferencePage_JMedTrasferJni,
+				getFieldEditorParent());
+		DirectoryFieldEditor dirEditor = new DirectoryFieldEditor(DL_DIR, Messages.PreferencePage_DownloadDir,
+				getFieldEditorParent());
+
+		jarEditor.getTextControl(getFieldEditorParent()).setMessage("Optional");//$NON-NLS-1$
+		iniEditor.getTextControl(getFieldEditorParent()).setMessage("Optional");//$NON-NLS-1$
+
+		addField(jarEditor);
+		addField(iniEditor);
+		addField(dirEditor);
 	}
 
 	public void init(final IWorkbench workbench) {

--- a/bundles/ch.elexis.laborimport_lg1/src/ch/elexis/laborimport/LG1/Importer.java
+++ b/bundles/ch.elexis.laborimport_lg1/src/ch/elexis/laborimport/LG1/Importer.java
@@ -114,16 +114,13 @@ public class Importer extends ImporterPage {
 	}
 
 	private Result<?> importDirect() {
-		if (openmedicalObject == null) {
-			return new Result<String>(SEVERITY.ERROR, 1, MY_LAB, "Fehlerhafte Konfiguration", true);
-		}
 		Result<String> result = new Result<String>("OK");
 
 		String downloadDirPath = CoreHub.localCfg.get(PreferencePage.DL_DIR, CoreHub.getTempDir().toString());
 		String iniPath = CoreHub.localCfg.get(PreferencePage.INI_PATH, null);
 
 		int res = -1;
-		if (iniPath != null) {
+		if (openmedicalObject != null && iniPath != null) {
 			try {
 				Object omResult = openmedicalDownloadMethod.invoke(openmedicalObject,
 						new Object[] { new String[] { "--download", downloadDirPath, "--logPath", downloadDirPath,
@@ -141,6 +138,7 @@ public class Importer extends ImporterPage {
 			}
 		}
 		// if (res > 0) {
+		res = 0;
 		File downloadDir = new File(downloadDirPath);
 		if (downloadDir.isDirectory()) {
 			File archiveDir = new File(downloadDir, "archive");
@@ -158,14 +156,23 @@ public class Importer extends ImporterPage {
 					return false;
 				}
 			});
+			Result<String> errors = new Result<>();
 			for (String file : files) {
 				File f = new File(downloadDir, file);
 				Result<?> rs;
 				try {
 					rs = hlp.importFile(f, archiveDir, false);
+					if (rs.isOK()) {
+						res++;
+					} else {
+						errors.addMessage(rs.getSeverity(), f.getName() + ": " + rs.getCombinedMessages()); //$NON-NLS-1$
+					}
 				} catch (IOException e) {
 					SWTHelper.showError("Import error", e.getMessage());
 				}
+			}
+			if (!errors.isOK()) {
+				SWTHelper.showInfo("Fehler beim Import", errors.getCombinedMessages().replace(", ", "\r\n"));
 			}
 			SWTHelper.showInfo("Verbindung mit Labor " + MY_LAB + " erfolgreich",
 					"Es wurden " + Integer.toString(res) + " Dateien verarbeitet");
@@ -319,10 +326,6 @@ public class Importer extends ImporterPage {
 
 				home.results[0] = new Integer(DIRECT).toString();
 				home.results[1] = StringUtils.EMPTY;
-			}
-
-			if (openmedicalObject == null) {
-				bDirect.setEnabled(false);
 			}
 
 			SelectionAdapter sa = new SelectionAdapter() {

--- a/bundles/ch.elexis.laborimport_lg1/src/ch/elexis/laborimport/LG1/PreferencePage.java
+++ b/bundles/ch.elexis.laborimport_lg1/src/ch/elexis/laborimport/LG1/PreferencePage.java
@@ -32,9 +32,19 @@ public class PreferencePage extends FieldEditorPreferencePage implements IWorkbe
 
 	@Override
 	protected void createFieldEditors() {
-		addField(new FileFieldEditor(JAR_PATH, Messages.PreferencePage_JMedTrasferJar, getFieldEditorParent()));
-		addField(new FileFieldEditor(INI_PATH, Messages.PreferencePage_JMedTrasferJni, getFieldEditorParent()));
-		addField(new DirectoryFieldEditor(DL_DIR, Messages.PreferencePage_DownloadDir, getFieldEditorParent()));
+		FileFieldEditor jarEditor = new FileFieldEditor(JAR_PATH, Messages.PreferencePage_JMedTrasferJar,
+				getFieldEditorParent());
+		FileFieldEditor iniEditor = new FileFieldEditor(INI_PATH, Messages.PreferencePage_JMedTrasferJni,
+				getFieldEditorParent());
+		DirectoryFieldEditor dirEditor = new DirectoryFieldEditor(DL_DIR, Messages.PreferencePage_DownloadDir,
+				getFieldEditorParent());
+
+		jarEditor.getTextControl(getFieldEditorParent()).setMessage("Optional");//$NON-NLS-1$
+		iniEditor.getTextControl(getFieldEditorParent()).setMessage("Optional");//$NON-NLS-1$
+
+		addField(jarEditor);
+		addField(iniEditor);
+		addField(dirEditor);
 	}
 
 	public void init(final IWorkbench workbench) {

--- a/bundles/ch.elexis.laborimport_lg1/src/ch/elexis/laborimport/LG1/messages.properties
+++ b/bundles/ch.elexis.laborimport_lg1/src/ch/elexis/laborimport/LG1/messages.properties
@@ -4,6 +4,8 @@ LabOrderAction_errorMessageNoPatientSelected=Bitte selektieren sie einen Patient
 
 LabOrderAction_errorTitleCannotCreateHL7=HL7 (V{0}) Datei kann nicht erstellt werden!
 
+LabOrderAction_errorTitleCannotShowURL=Cannot show URL!
+
 LabOrderAction_errorTitleNoFallSelected=Kein Fall ausgewählt!
 
 LabOrderAction_errorTitleNoPatientSelected=Kein Patient ausgewählt!
@@ -19,3 +21,9 @@ LabOrderAction_receivingApplication=IMED
 LabOrderAction_receivingFacility=PRAXIS
 
 Lg1PreferencePage_labelUploadDir=Upload Verzeichnis Auftrag
+
+PreferencePage_DownloadDir=download directory
+
+PreferencePage_JMedTrasferJni=OpenMedical configuration (MedTransfer.ini)
+
+PreferencePage_JMedTrasferJar=OpenMedical library (JMedTransferO.jar)

--- a/bundles/ch.elexis.laborimport_lg1/src/ch/elexis/laborimport/LG1/messages_de.properties
+++ b/bundles/ch.elexis.laborimport_lg1/src/ch/elexis/laborimport/LG1/messages_de.properties
@@ -4,6 +4,8 @@ LabOrderAction_errorMessageNoPatientSelected=Bitte selektieren sie einen Patient
 
 LabOrderAction_errorTitleCannotCreateHL7=HL7 (V{0}) Datei kann nicht erstellt werden!
 
+LabOrderAction_errorTitleCannotShowURL=Kann URL nicht anzeigen!
+
 LabOrderAction_errorTitleNoFallSelected=Kein Fall ausgewählt!
 
 LabOrderAction_errorTitleNoPatientSelected=Kein Patient ausgewählt!
@@ -19,3 +21,9 @@ LabOrderAction_receivingApplication=IMED
 LabOrderAction_receivingFacility=PRAXIS
 
 Lg1PreferencePage_labelUploadDir=Upload Verzeichnis Auftrag
+
+PreferencePage_DownloadDir=Download Verzeichnis
+
+PreferencePage_JMedTrasferJni=OpenMedical Konfiguration (MedTransfer.ini)
+
+PreferencePage_JMedTrasferJar=OpenMedical Bibliothek (JMedTransferO.jar)

--- a/bundles/ch.elexis.laborimport_lg1/src/ch/elexis/laborimport/LG1/messages_en.properties
+++ b/bundles/ch.elexis.laborimport_lg1/src/ch/elexis/laborimport/LG1/messages_en.properties
@@ -4,6 +4,8 @@ LabOrderAction_errorMessageNoPatientSelected=Please select a patient
 
 LabOrderAction_errorTitleCannotCreateHL7=HL7 (V {0}) file can not be created!
 
+LabOrderAction_errorTitleCannotShowURL=Cannot show URL!
+
 LabOrderAction_errorTitleNoFallSelected=No case selected!
 
 LabOrderAction_errorTitleNoPatientSelected=No patient selected!
@@ -19,3 +21,9 @@ LabOrderAction_receivingApplication=IMED
 LabOrderAction_receivingFacility=PRACTICE
 
 Lg1PreferencePage_labelUploadDir=Upload directory order
+
+PreferencePage_DownloadDir=download directory
+
+PreferencePage_JMedTrasferJni=OpenMedical configuration (MedTransfer.ini)
+
+PreferencePage_JMedTrasferJar=OpenMedical library (JMedTransferO.jar)

--- a/bundles/ch.elexis.laborimport_lg1/src/ch/elexis/laborimport/LG1/messages_fr.properties
+++ b/bundles/ch.elexis.laborimport_lg1/src/ch/elexis/laborimport/LG1/messages_fr.properties
@@ -4,6 +4,8 @@ LabOrderAction_errorMessageNoPatientSelected=S'il vous plaît sélectionner un pat
 
 LabOrderAction_errorTitleCannotCreateHL7=Le fichier HL7 (V {0}) ne peut pas être créé!
 
+LabOrderAction_errorTitleCannotShowURL=Impossible d'afficher l'URL!
+
 LabOrderAction_errorTitleNoFallSelected=Aucun cas sélectionné!
 
 LabOrderAction_errorTitleNoPatientSelected=Aucun patient sélectionné!
@@ -19,3 +21,9 @@ LabOrderAction_receivingApplication=IMED
 LabOrderAction_receivingFacility=PRATIQUE
 
 Lg1PreferencePage_labelUploadDir=Télécharger l'ordre du répertoire
+
+PreferencePage_DownloadDir=r\u00E9pertoire de t\u00E9l\u00E9chargement
+
+PreferencePage_JMedTrasferJar = Biblioth\u00E8que ouverte m\u00E9dicale (JMedTransferO.jar)
+
+PreferencePage_JMedTrasferJni = configuration ouverte m\u00E9dicale (MedTransfer.ini)

--- a/bundles/ch.elexis.laborimport_lg1/src/ch/elexis/laborimport/LG1/messages_it.properties
+++ b/bundles/ch.elexis.laborimport_lg1/src/ch/elexis/laborimport/LG1/messages_it.properties
@@ -4,6 +4,8 @@ LabOrderAction_errorMessageNoPatientSelected=Si prega di selezionare un paziente
 
 LabOrderAction_errorTitleCannotCreateHL7=Il file HL7 (V {0}) non può essere creato!
 
+LabOrderAction_errorTitleCannotShowURL=Non \u00E8 possibile visualizzare l'URL!
+
 LabOrderAction_errorTitleNoFallSelected=Nessun caso selezionato!
 
 LabOrderAction_errorTitleNoPatientSelected=Nessun paziente selezionato!
@@ -19,3 +21,9 @@ LabOrderAction_receivingApplication=IMED
 LabOrderAction_receivingFacility=PRATICA
 
 Lg1PreferencePage_labelUploadDir=Carica ordine directory
+
+PreferencePage_DownloadDir=cartella di download
+
+PreferencePage_JMedTrasferJar = Aprire Medical Library (JMedTransferO.jar)
+
+PreferencePage_JMedTrasferJni = Medical configurazione aperta (MedTransfer.ini)

--- a/bundles/ch.elexis.laborimport_rischbern/src/ch/elexis/laborimport/RischBern/Importer.java
+++ b/bundles/ch.elexis.laborimport_rischbern/src/ch/elexis/laborimport/RischBern/Importer.java
@@ -113,16 +113,13 @@ public class Importer extends ImporterPage {
 	}
 
 	private Result<?> importDirect() {
-		if (openmedicalObject == null) {
-			return new Result<String>(SEVERITY.ERROR, 1, MY_LAB, "Fehlerhafte Konfiguration", true);
-		}
 		Result<String> result = new Result<String>("OK");
 
 		String downloadDirPath = CoreHub.localCfg.get(PreferencePage.DL_DIR, CoreHub.getTempDir().toString());
 		String iniPath = CoreHub.localCfg.get(PreferencePage.INI_PATH, null);
 
 		int res = -1;
-		if (iniPath != null) {
+		if (openmedicalObject != null && iniPath != null) {
 			try {
 				Object omResult = openmedicalDownloadMethod.invoke(openmedicalObject,
 						new Object[] { new String[] { "--download", downloadDirPath, "--logPath", downloadDirPath,
@@ -140,6 +137,7 @@ public class Importer extends ImporterPage {
 			}
 		}
 		// if (res > 0) {
+		res = 0;
 		File downloadDir = new File(downloadDirPath);
 		if (downloadDir.isDirectory()) {
 			File archiveDir = new File(downloadDir, "archive");
@@ -157,14 +155,24 @@ public class Importer extends ImporterPage {
 					return false;
 				}
 			});
+			Result<String> errors = new Result<String>();
 			for (String file : files) {
 				File f = new File(downloadDir, file);
 				Result<?> rs;
 				try {
 					rs = hlp.importFile(f, archiveDir, false);
+					if (rs.isOK()) {
+						res++;
+					} else {
+						errors.addMessage(rs.getSeverity(), f.getName()
+								+ ": " + rs.getCombinedMessages()); //$NON-NLS-1$
+					}
 				} catch (IOException e) {
 					SWTHelper.showError("Import error", e.getMessage());
 				}
+			}
+			if (!errors.isOK()) {
+				SWTHelper.showInfo("Fehler beim Import", errors.getCombinedMessages().replace(", ", "\r\n"));
 			}
 			SWTHelper.showInfo("Verbindung mit Labor " + MY_LAB + " erfolgreich",
 					"Es wurden " + Integer.toString(res) + " Dateien verarbeitet");
@@ -290,10 +298,6 @@ public class Importer extends ImporterPage {
 
 				home.results[0] = new Integer(DIRECT).toString();
 				home.results[1] = StringUtils.EMPTY;
-			}
-
-			if (openmedicalObject == null) {
-				bDirect.setEnabled(false);
 			}
 
 			SelectionAdapter sa = new SelectionAdapter() {

--- a/bundles/ch.elexis.laborimport_rischbern/src/ch/elexis/laborimport/RischBern/PreferencePage.java
+++ b/bundles/ch.elexis.laborimport_rischbern/src/ch/elexis/laborimport/RischBern/PreferencePage.java
@@ -35,9 +35,19 @@ public class PreferencePage extends FieldEditorPreferencePage implements IWorkbe
 
 	@Override
 	protected void createFieldEditors() {
-		addField(new FileFieldEditor(JAR_PATH, Messages.PreferencePage_JMedTrasferJar, getFieldEditorParent()));
-		addField(new FileFieldEditor(INI_PATH, Messages.PreferencePage_JMedTrasferJni, getFieldEditorParent()));
-		addField(new DirectoryFieldEditor(DL_DIR, Messages.PreferencePage_DownloadDir, getFieldEditorParent()));
+		FileFieldEditor jarEditor = new FileFieldEditor(JAR_PATH, Messages.PreferencePage_JMedTrasferJar,
+				getFieldEditorParent());
+		FileFieldEditor iniEditor = new FileFieldEditor(INI_PATH, Messages.PreferencePage_JMedTrasferJni,
+				getFieldEditorParent());
+		DirectoryFieldEditor dirEditor = new DirectoryFieldEditor(DL_DIR, Messages.PreferencePage_DownloadDir,
+				getFieldEditorParent());
+		
+		jarEditor.getTextControl(getFieldEditorParent()).setMessage("Optional");//$NON-NLS-1$
+		iniEditor.getTextControl(getFieldEditorParent()).setMessage("Optional");//$NON-NLS-1$
+
+		addField(jarEditor);
+		addField(iniEditor);
+		addField(dirEditor);
 	}
 
 	public void init(final IWorkbench workbench) {

--- a/bundles/ch.elexis.laborimport_rothen/src/ch/elexis/laborimport/Rothen/Importer.java
+++ b/bundles/ch.elexis.laborimport_rothen/src/ch/elexis/laborimport/Rothen/Importer.java
@@ -113,16 +113,13 @@ public class Importer extends ImporterPage {
 	}
 
 	private Result<?> importDirect() {
-		if (openmedicalObject == null) {
-			return new Result<String>(SEVERITY.ERROR, 1, MY_LAB, "Fehlerhafte Konfiguration", true);
-		}
 		Result<String> result = new Result<String>("OK");
 
 		String downloadDirPath = CoreHub.localCfg.get(PreferencePage.DL_DIR, CoreHub.getTempDir().toString());
 		String iniPath = CoreHub.localCfg.get(PreferencePage.INI_PATH, null);
 
 		int res = -1;
-		if (iniPath != null) {
+		if (openmedicalObject != null && iniPath != null) {
 			try {
 				Object omResult = openmedicalDownloadMethod.invoke(openmedicalObject,
 						new Object[] { new String[] { "--download", downloadDirPath, "--logPath", downloadDirPath,
@@ -140,6 +137,7 @@ public class Importer extends ImporterPage {
 			}
 		}
 		// if (res > 0) {
+		res = 0;
 		File downloadDir = new File(downloadDirPath);
 		if (downloadDir.isDirectory()) {
 			File archiveDir = new File(downloadDir, "archive");
@@ -157,14 +155,24 @@ public class Importer extends ImporterPage {
 					return false;
 				}
 			});
+			Result<String> errors = new Result<>();
 			for (String file : files) {
 				File f = new File(downloadDir, file);
 				Result<?> rs;
 				try {
 					rs = hlp.importFile(f, archiveDir, false);
+					if (rs.isOK()) {
+						res++;
+					} else {
+						errors.addMessage(rs.getSeverity(), f.getName()
+								+ ": " + rs.getCombinedMessages()); //$NON-NLS-1$
+					}
 				} catch (IOException e) {
 					SWTHelper.showError("Import error", e.getMessage());
 				}
+			}
+			if (!errors.isOK()) {
+				SWTHelper.showInfo("Fehler beim Import", errors.getCombinedMessages().replace(", ", "\r\n"));
 			}
 			SWTHelper.showInfo("Verbindung mit Labor " + MY_LAB + " erfolgreich",
 					"Es wurden " + Integer.toString(res) + " Dateien verarbeitet");
@@ -290,10 +298,6 @@ public class Importer extends ImporterPage {
 
 				home.results[0] = new Integer(DIRECT).toString();
 				home.results[1] = StringUtils.EMPTY;
-			}
-
-			if (openmedicalObject == null) {
-				bDirect.setEnabled(false);
 			}
 
 			SelectionAdapter sa = new SelectionAdapter() {

--- a/bundles/ch.elexis.laborimport_rothen/src/ch/elexis/laborimport/Rothen/PreferencePage.java
+++ b/bundles/ch.elexis.laborimport_rothen/src/ch/elexis/laborimport/Rothen/PreferencePage.java
@@ -35,9 +35,19 @@ public class PreferencePage extends FieldEditorPreferencePage implements IWorkbe
 
 	@Override
 	protected void createFieldEditors() {
-		addField(new FileFieldEditor(JAR_PATH, Messages.PreferencePage_JMedTrasferJar, getFieldEditorParent()));
-		addField(new FileFieldEditor(INI_PATH, Messages.PreferencePage_JMedTrasferJni, getFieldEditorParent()));
-		addField(new DirectoryFieldEditor(DL_DIR, Messages.PreferencePage_DownloadDir, getFieldEditorParent()));
+		FileFieldEditor jarEditor = new FileFieldEditor(JAR_PATH, Messages.PreferencePage_JMedTrasferJar,
+				getFieldEditorParent());
+		FileFieldEditor iniEditor = new FileFieldEditor(INI_PATH, Messages.PreferencePage_JMedTrasferJni,
+				getFieldEditorParent());
+		DirectoryFieldEditor dirEditor = new DirectoryFieldEditor(DL_DIR, Messages.PreferencePage_DownloadDir,
+				getFieldEditorParent());
+
+		jarEditor.getTextControl(getFieldEditorParent()).setMessage("Optional");//$NON-NLS-1$
+		iniEditor.getTextControl(getFieldEditorParent()).setMessage("Optional");//$NON-NLS-1$
+
+		addField(jarEditor);
+		addField(iniEditor);
+		addField(dirEditor);
 	}
 
 	public void init(final IWorkbench workbench) {

--- a/bundles/ch.elexis.laborimport_viollier/src/ch/elexis/laborimport/viollier/Messages.java
+++ b/bundles/ch.elexis.laborimport_viollier/src/ch/elexis/laborimport/viollier/Messages.java
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) 2007-2010, G. Weirich and Elexis
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     G. Weirich - initial API and implementation
+ * All the rest is done generically. See plug-in elexis-importer.
+ *
+ */
+package ch.elexis.laborimport.viollier;
+
+public class Messages {
+	public static String PreferencePage_DownloadDir = ch.elexis.core.l10n.Messages.Core_Download_Directory;
+	public static String PreferencePage_JMedTrasferJar = ch.elexis.core.l10n.Messages.PreferencePage_JMedTrasferJar;
+	public static String PreferencePage_JMedTrasferJni = ch.elexis.core.l10n.Messages.PreferencePage_JMedTrasferJni;
+
+}

--- a/bundles/ch.elexis.laborimport_viollier/src/ch/elexis/laborimport/viollier/PreferencePage.java
+++ b/bundles/ch.elexis.laborimport_viollier/src/ch/elexis/laborimport/viollier/PreferencePage.java
@@ -26,9 +26,9 @@ import ch.elexis.core.ui.preferences.SettingsPreferenceStore;
 
 public class PreferencePage extends FieldEditorPreferencePage implements IWorkbenchPreferencePage {
 
-	public static final String JAR_PATH = "viollier/jar_path";
-	public static final String INI_PATH = "viollier/ini_path";
-	public static final String DL_DIR = "viollier/downloaddir";
+	public static final String JAR_PATH = "viollier/jar_path"; //$NON-NLS-1$
+	public static final String INI_PATH = "viollier/ini_path"; //$NON-NLS-1$
+	public static final String DL_DIR = "viollier/downloaddir"; //$NON-NLS-1$
 
 	public PreferencePage() {
 		super(GRID);
@@ -37,9 +37,19 @@ public class PreferencePage extends FieldEditorPreferencePage implements IWorkbe
 
 	@Override
 	protected void createFieldEditors() {
-		addField(new FileFieldEditor(JAR_PATH, "OpenMedical Bibliothek (JMedTransferO.jar)", getFieldEditorParent()));
-		addField(new FileFieldEditor(INI_PATH, "OpenMedical Konfiguration (MedTransfer.ini)", getFieldEditorParent()));
-		addField(new DirectoryFieldEditor(DL_DIR, "Download Verzeichnis", getFieldEditorParent()));
+		FileFieldEditor jarEditor = new FileFieldEditor(JAR_PATH, Messages.PreferencePage_JMedTrasferJar,
+				getFieldEditorParent());
+		FileFieldEditor iniEditor = new FileFieldEditor(INI_PATH, Messages.PreferencePage_JMedTrasferJni,
+				getFieldEditorParent());
+		DirectoryFieldEditor dirEditor = new DirectoryFieldEditor(DL_DIR, Messages.PreferencePage_DownloadDir,
+				getFieldEditorParent());
+
+		jarEditor.getTextControl(getFieldEditorParent()).setMessage("Optional");//$NON-NLS-1$
+		iniEditor.getTextControl(getFieldEditorParent()).setMessage("Optional");//$NON-NLS-1$
+
+		addField(jarEditor);
+		addField(iniEditor);
+		addField(dirEditor);
 	}
 
 	public void init(final IWorkbench workbench) {


### PR DESCRIPTION
folgende Importer wurden bearbeitet:

- Bioanalytica
- RischBern
- Rothen
- Viollier
- LG1
- Synlab (MEDISYN)

was bei jedem gemacht wurde:

- In der PreferencePage sollen die zwei OpenMedical-Konfig-Felder einen Standardtext "Optional" haben.
- Im Importer soll der Radiobutton für den Direktimport **nicht** deaktiviert werden, wenn openmedical nicht konfiguriert ist.
- Der Direktimport funktioniert auch ohne openmedical.

mir ist noch aufgefallen:

1. bei LG1 haben bei mir die Messages Strings nie funktioniert, da sie in keinen der messages.properties Dateien definiert waren.
2. beim Importer von Synlab ist kommentiert, dass importFile Errors gezeigt werden. Dies konnte ich aber nicht nachweisen bei einem Testimport. Was aber passiert, ist, dass die Datei in ein "error" Verzeichnis verschoben wird. Das Verschieben wird dem User auch nicht mitgeteilt.
3. bei viollier und bioanalytica waren die PreferencePage-Strings nicht internationalisiert, ich habe bei den zwei Importern eine Messages Klasse hinzugefügt.