### PR TITLE
Reconfigured null check to overcome NPEs triggered by .getDomainId()

### DIFF
--- a/bundles/ch.framsteg.elexis.labor.teamw/src/ch/framsteg/elexis/labor/teamw/views/LabordersView.java
+++ b/bundles/ch.framsteg.elexis.labor.teamw/src/ch/framsteg/elexis/labor/teamw/views/LabordersView.java
@@ -236,9 +236,13 @@ public class LabordersView extends ViewPart implements IRefreshable {
 		}
 
 		if (coverage.getCostBearer() != null) {
-			txtCaseInsuranceEAN.setText(coverage.getCostBearer()
-					.getXid(getApplicationProperties().getProperty(APP_CFG_XID_EAN)).getDomainId());
+			txtCaseInsuranceEAN.setText(
+					coverage.getCostBearer().getXid(getApplicationProperties().getProperty(APP_CFG_XID_EAN)) != null
+							? coverage.getCostBearer().getXid(getApplicationProperties().getProperty(APP_CFG_XID_EAN))
+									.getDomainId()
+							: "");
 		}
+
 		if (txtCaseInsuranceEAN.getText().isEmpty()) {
 			txtCaseInsuranceEAN.setBackground(getMarkedBackgroundColor());
 			txtCaseInsuranceEAN.setText(getMessagesProperties().getProperty(MSG_EMPTY_FIELD));


### PR DESCRIPTION
[26757] Corrected fault null check in ch.framsteg.elexis.labor.teamw 