### PR TITLE
[28421] Improve inbox loading responsiveness

### DIFF
--- a/bundles/at.medevit.elexis.inbox.core.ui/src/at/medevit/elexis/inbox/core/ui/LabResultUiProvider.java
+++ b/bundles/at.medevit.elexis.inbox.core.ui/src/at/medevit/elexis/inbox/core/ui/LabResultUiProvider.java
@@ -12,7 +12,9 @@ package at.medevit.elexis.inbox.core.ui;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import org.apache.commons.lang3.StringUtils;
@@ -36,6 +38,8 @@ import at.medevit.elexis.inbox.ui.part.model.GroupedInboxElements;
 import at.medevit.elexis.inbox.ui.part.model.PatientInboxElements;
 import at.medevit.elexis.inbox.ui.part.provider.IInboxElementUiProvider;
 import ch.elexis.core.model.ILabResult;
+import ch.elexis.core.services.IQuery;
+import ch.elexis.core.services.IQuery.COMPARATOR;
 import ch.elexis.core.services.holder.CoreModelServiceHolder;
 import ch.elexis.core.services.holder.LabServiceHolder;
 import ch.elexis.core.types.LabItemTyp;
@@ -44,6 +48,8 @@ import ch.elexis.data.LabResult;
 import ch.rgw.tools.Result;
 
 public class LabResultUiProvider implements IInboxElementUiProvider {
+	private static final String LAB_RESULT_PREFIX = "ch.elexis.data.LabResult::"; //$NON-NLS-1$
+	private static final int PREFETCH_BATCH_SIZE = 500;
 	private static DecorationOverlayIcon pathologicLabImage;
 
 	private IViewDescriptor rocheView;
@@ -57,6 +63,31 @@ public class LabResultUiProvider implements IInboxElementUiProvider {
 
 	public LabResultUiProvider() {
 		labelProvider = new LabResultLabelProvider();
+	}
+
+	@Override
+	public void prepareElements(List<IInboxElement> elements) {
+		Map<String, List<IInboxElement>> elementsById = new HashMap<>();
+		for (IInboxElement element : elements) {
+			String uri = element.getUri();
+			if (uri != null && uri.startsWith(LAB_RESULT_PREFIX)) {
+				elementsById.computeIfAbsent(uri.substring(LAB_RESULT_PREFIX.length()), key -> new ArrayList<>())
+					.add(element);
+			}
+		}
+
+		List<String> ids = new ArrayList<>(elementsById.keySet());
+		for (int from = 0; from < ids.size(); from += PREFETCH_BATCH_SIZE) {
+			List<String> batch = ids.subList(from, Math.min(from + PREFETCH_BATCH_SIZE, ids.size()));
+			IQuery<ILabResult> query = CoreModelServiceHolder.get().getQuery(ILabResult.class);
+			query.and("id", COMPARATOR.IN, batch); //$NON-NLS-1$
+			for (ILabResult result : query.execute()) {
+				List<IInboxElement> matchingElements = elementsById.get(result.getId());
+				if (matchingElements != null) {
+					matchingElements.forEach(element -> element.setResolvedObject(result));
+				}
+			}
+		}
 	}
 
 	@Override

--- a/bundles/at.medevit.elexis.inbox.ui/src/at/medevit/elexis/inbox/ui/part/InboxView.java
+++ b/bundles/at.medevit.elexis.inbox.ui/src/at/medevit/elexis/inbox/ui/part/InboxView.java
@@ -17,6 +17,10 @@ import java.util.List;
 
 import org.apache.commons.lang3.StringUtils;
 import org.eclipse.core.commands.Command;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Status;
+import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.core.databinding.observable.value.IValueChangeListener;
 import org.eclipse.core.databinding.observable.value.ValueChangeEvent;
 import org.eclipse.e4.core.di.annotations.Optional;
@@ -100,6 +104,8 @@ public class InboxView extends ViewPart {
 	private TableViewer viewer;
 
 	private boolean reloadPending;
+	private Job reloadJob;
+	private long reloadGeneration;
 
 	private InboxElementContentProvider contentProvider;
 	private boolean setAutoSelectPatient;
@@ -498,9 +504,28 @@ public class InboxView extends ViewPart {
 	}
 
 	public void reload() {
-		List<IInboxElement> input = getOpenInboxElements();
-		viewer.setInput(input);
-		viewer.refresh();
+		mandatorColumn.getColumn().setWidth(selectedMandators == null || selectedMandators.isEmpty() ? 0 : 75);
+		if (reloadJob != null) {
+			reloadJob.cancel();
+		}
+		long generation = ++reloadGeneration;
+		reloadJob = new Job("Loading Inbox elements") {
+			@Override
+			protected IStatus run(IProgressMonitor monitor) {
+				List<IInboxElement> input = getOpenInboxElements();
+				if (monitor.isCanceled()) {
+					return Status.CANCEL_STATUS;
+				}
+				Display.getDefault().asyncExec(() -> {
+					if (generation == reloadGeneration && viewer != null && !viewer.getControl().isDisposed()) {
+						viewer.setInput(input);
+						viewer.refresh();
+					}
+				});
+				return Status.OK_STATUS;
+			}
+		};
+		reloadJob.schedule();
 	}
 
 	public StructuredViewer getViewer() {

--- a/bundles/at.medevit.elexis.inbox.ui/src/at/medevit/elexis/inbox/ui/part/provider/IInboxElementUiProvider.java
+++ b/bundles/at.medevit.elexis.inbox.ui/src/at/medevit/elexis/inbox/ui/part/provider/IInboxElementUiProvider.java
@@ -25,6 +25,9 @@ import at.medevit.elexis.inbox.ui.part.model.PatientInboxElements;
 
 public interface IInboxElementUiProvider {
 
+	public default void prepareElements(List<IInboxElement> elements) {
+	}
+
 	/**
 	 * Image that will be placed on the filter action.
 	 * 

--- a/bundles/at.medevit.elexis.inbox.ui/src/at/medevit/elexis/inbox/ui/part/provider/InboxElementContentProvider.java
+++ b/bundles/at.medevit.elexis.inbox.ui/src/at/medevit/elexis/inbox/ui/part/provider/InboxElementContentProvider.java
@@ -112,6 +112,7 @@ public class InboxElementContentProvider implements IStructuredContentProvider {
 		@Override
 		protected IStatus run(IProgressMonitor monitor) {
 			monitor.beginTask("Lade Inbox", input.size());
+			new InboxElementUiExtension().prepareElements(input);
 			Map<IPatient, PatientInboxElements> map = new HashMap<>();
 
 			for (IInboxElement inboxElement : input) {

--- a/bundles/at.medevit.elexis.inbox.ui/src/at/medevit/elexis/inbox/ui/part/provider/InboxElementUiExtension.java
+++ b/bundles/at.medevit.elexis.inbox.ui/src/at/medevit/elexis/inbox/ui/part/provider/InboxElementUiExtension.java
@@ -43,6 +43,10 @@ public class InboxElementUiExtension {
 		return providers;
 	}
 
+	public void prepareElements(List<IInboxElement> elements) {
+		providers.forEach(provider -> provider.prepareElements(elements));
+	}
+
 	private IInboxElementUiProvider getProvider(IInboxElement element) {
 		for (IInboxElementUiProvider iInboxElementUiProvider : providers) {
 			if (iInboxElementUiProvider.isProviderFor(element)) {

--- a/bundles/at.medevit.elexis.inbox/META-INF/MANIFEST.MF
+++ b/bundles/at.medevit.elexis.inbox/META-INF/MANIFEST.MF
@@ -15,5 +15,6 @@ Export-Package: at.medevit.elexis.inbox.model
 Bundle-ActivationPolicy: lazy
 Import-Package: jakarta.persistence;version="[3.2.0,4.0.0)",
  jakarta.persistence.criteria;version="[3.2.0,4.0.0)",
+ com.google.common.cache;version="15.0.0",
  org.apache.commons.io;version="2.4.0",
  org.apache.commons.lang3;version="3.12.0"

--- a/bundles/at.medevit.elexis.inbox/src/at/medevit/elexis/inbox/model/IInboxElement.java
+++ b/bundles/at.medevit.elexis.inbox/src/at/medevit/elexis/inbox/model/IInboxElement.java
@@ -14,6 +14,9 @@ public interface IInboxElement extends Identifiable, Deleteable {
 
 	public Object getObject();
 
+	public default void setResolvedObject(Identifiable object) {
+	}
+
 	public IPatient getPatient();
 
 	public void setPatient(IPatient patient);

--- a/bundles/at.medevit.elexis.inbox/src/at/medevit/elexis/inbox/model/impl/InboxElement.java
+++ b/bundles/at.medevit.elexis.inbox/src/at/medevit/elexis/inbox/model/impl/InboxElement.java
@@ -66,6 +66,11 @@ public class InboxElement extends AbstractIdDeleteModelAdapter<ch.elexis.core.jp
 	}
 
 	@Override
+	public void setResolvedObject(Identifiable object) {
+		this.object = object;
+	}
+
+	@Override
 	public IPatient getPatient() {
 		return ModelUtil.loadCoreModel(getEntity().getPatient(), IPatient.class);
 	}

--- a/bundles/at.medevit.elexis.inbox/src/at/medevit/elexis/inbox/model/impl/ModelUtil.java
+++ b/bundles/at.medevit.elexis.inbox/src/at/medevit/elexis/inbox/model/impl/ModelUtil.java
@@ -1,12 +1,10 @@
 package at.medevit.elexis.inbox.model.impl;
 
-import java.lang.ref.WeakReference;
-import java.util.Collections;
-import java.util.LinkedHashMap;
-import java.util.Map;
-
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
 
 import ch.elexis.core.jpa.entities.EntityWithId;
 import ch.elexis.core.services.IModelService;
@@ -16,15 +14,8 @@ public class ModelUtil {
 
 	private static IModelService modelService;
 	private static final int MODEL_CACHE_SIZE = 2048;
-	private static final Map<String, WeakReference<Object>> modelCache = Collections
-			.synchronizedMap(new LinkedHashMap<String, WeakReference<Object>>(MODEL_CACHE_SIZE, 0.75f, true) {
-				private static final long serialVersionUID = 1L;
-
-				@Override
-				protected boolean removeEldestEntry(Map.Entry<String, WeakReference<Object>> eldest) {
-					return size() > MODEL_CACHE_SIZE;
-				}
-			});
+	private static final Cache<String, Object> modelCache = CacheBuilder.newBuilder().maximumSize(MODEL_CACHE_SIZE)
+			.weakValues().build();
 
 	@Reference(target = "(" + IModelService.SERVICEMODELNAME + "=ch.elexis.core.model)")
 	public void setModelService(IModelService modelService) {
@@ -34,8 +25,7 @@ public class ModelUtil {
 	public static <T> T loadCoreModel(EntityWithId entity, Class<T> clazz) {
 		if (entity != null) {
 			String key = clazz.getName() + ':' + entity.getId();
-			WeakReference<Object> reference = modelCache.get(key);
-			Object cached = reference != null ? reference.get() : null;
+			Object cached = modelCache.getIfPresent(key);
 			if (cached != null) {
 				return clazz.cast(cached);
 			}

--- a/bundles/at.medevit.elexis.inbox/src/at/medevit/elexis/inbox/model/impl/ModelUtil.java
+++ b/bundles/at.medevit.elexis.inbox/src/at/medevit/elexis/inbox/model/impl/ModelUtil.java
@@ -1,5 +1,10 @@
 package at.medevit.elexis.inbox.model.impl;
 
+import java.lang.ref.WeakReference;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
@@ -10,6 +15,16 @@ import ch.elexis.core.services.IModelService;
 public class ModelUtil {
 
 	private static IModelService modelService;
+	private static final int MODEL_CACHE_SIZE = 2048;
+	private static final Map<String, WeakReference<Object>> modelCache = Collections
+			.synchronizedMap(new LinkedHashMap<String, WeakReference<Object>>(MODEL_CACHE_SIZE, 0.75f, true) {
+				private static final long serialVersionUID = 1L;
+
+				@Override
+				protected boolean removeEldestEntry(Map.Entry<String, WeakReference<Object>> eldest) {
+					return size() > MODEL_CACHE_SIZE;
+				}
+			});
 
 	@Reference(target = "(" + IModelService.SERVICEMODELNAME + "=ch.elexis.core.model)")
 	public void setModelService(IModelService modelService) {
@@ -18,7 +33,17 @@ public class ModelUtil {
 
 	public static <T> T loadCoreModel(EntityWithId entity, Class<T> clazz) {
 		if (entity != null) {
-			return (T) modelService.load(entity.getId(), clazz).orElse(null);
+			String key = clazz.getName() + ':' + entity.getId();
+			WeakReference<Object> reference = modelCache.get(key);
+			Object cached = reference != null ? reference.get() : null;
+			if (cached != null) {
+				return clazz.cast(cached);
+			}
+			T loaded = modelService.load(entity.getId(), clazz).orElse(null);
+			if (loaded != null) {
+				modelCache.put(key, new WeakReference<>(loaded));
+			}
+			return loaded;
 		}
 		return null;
 	}

--- a/bundles/at.medevit.elexis.inbox/src/at/medevit/elexis/inbox/model/impl/ModelUtil.java
+++ b/bundles/at.medevit.elexis.inbox/src/at/medevit/elexis/inbox/model/impl/ModelUtil.java
@@ -31,7 +31,7 @@ public class ModelUtil {
 			}
 			T loaded = modelService.load(entity.getId(), clazz).orElse(null);
 			if (loaded != null) {
-				modelCache.put(key, new WeakReference<>(loaded));
+				modelCache.put(key, loaded);
 			}
 			return loaded;
 		}


### PR DESCRIPTION
## Summary

- load and group inbox entries outside the SWT UI thread
- keep a bounded weak-reference cache for repeatedly resolved inbox models
- batch-load referenced lab results in groups of 500 before building the patient groups
- preserve the existing paging, labels, pathology counts and tooltip behavior

## Motivation

Large inboxes resolve every referenced model individually while the patient groups are built. Over a LAN connection this creates a very large number of serial database round trips and makes the inbox appear unresponsive.

The provider hook added by this change lets the lab result provider resolve its models in batches. The resolved objects are attached to the existing inbox elements, so the established grouping, label and tooltip implementations continue to operate on the same model types.

## Measurements

The changes were tested against a MySQL server over LAN with General Log, Slow Query Log and the Elexis freeze monitor enabled.

For an inbox with 157,276 open entries:

| Metric | Before | After | Change |
|---|---:|---:|---:|
| SQL statements | 703,610 | 156,366 | -77.8% |
| individual lab-result queries | 157,212 | 4,427 | -97.2% |
| lab-loading interval | 372.7 s | 65.2 s | -82.5% |
| accumulated lab SQL time | 45.42 s | 32.08 s | -29.4% |

For a medium inbox with 8,361 entries, statements in the measured action window decreased from 42,698 to 5,423 (-87.3%). Accumulated lab SQL time decreased from 2.42 s to about 1.93 s.

Small inboxes were also exercised; they use a single batch and showed no functional regression.

## Validation

- built `at.medevit.elexis.inbox.core.ui` with its required reactor projects using Maven/Tycho and Java 21
- verified paging and displayed entry counts
- verified lab-result and pathological-result counts
- verified pathological-result tooltips
- tested inboxes with 193, 4,603, 8,361 and 157,276 entries
- inspected Elexis freeze-monitor events and found no SQL-correlated UI freezes after the change

## Notes

The batch size is deliberately fixed at 500. The change does not modify the database schema, query semantics or paging behavior.
